### PR TITLE
Stat Tile: lightning_strike_count should show the sum

### DIFF
--- a/bin/user/weewx_wdc.py
+++ b/bin/user/weewx_wdc.py
@@ -724,7 +724,7 @@ class WdcStatsUtil(SearchList):
         Returns:
             bool: Show or hide sum stat.
         """
-        show_sum = ["rain", "ET"]
+        show_sum = ["rain", "ET", "lightning_strike_count"]
 
         if observation in show_sum:
             return True


### PR DESCRIPTION
The `lightning_strike_count` stat tile currently shows the maximum for
the given range, which isn't optimal.

This PR changes the tile to behave like the `rain` or the `ET` tile.