### PR TITLE
fix(mqtt): Handle observations with underscores

### DIFF
--- a/skins/weewx-wdc/src/js/live-updates.ts
+++ b/skins/weewx-wdc/src/js/live-updates.ts
@@ -22,6 +22,21 @@ const notfication = websiteMessageContainer!.querySelector(
   "bx-inline-notification"
 );
 
+const _splitMQTTProp = (key: string): string[] => {
+  const underscoreObservations = /^(pm\d+_\d|lightning_[a-z]+_count|lightning_distance|lightning_energy)_(.+)/;
+  const matchedKey = key.match(underscoreObservations);
+
+  if (Array.isArray(matchedKey)) {
+    const observation = matchedKey[1];
+    const splitted = matchedKey[2].split("_");
+    splitted.unshift(observation);
+
+    return splitted;
+  } else {
+    return key.split("_");
+  }
+};
+
 const _getUnitFromMQTTProp = (keySplitted: string[]): string => {
   let unitMQTT = "";
 
@@ -332,7 +347,7 @@ const onMessageArrived = (message: Message) => {
   for (const key in payLoad) {
     if (["dateTime", "usUnits", "interval"].includes(key)) continue;
 
-    const keySplitted = key.split("_");
+    const keySplitted = _splitMQTTProp(key);
     const observation = keySplitted[0];
     const unitMQTT = _getUnitFromMQTTProp(keySplitted);
 


### PR DESCRIPTION
Some (extended) weewx observations already include an underscore in their name, which means that simply splitting on `_` didn't work as expected for at least the following observations:

- `lightning_distance`
- `lightning_disturber_count`
- `lightning_energy`
- `lightning_noise_count`
- `lightning_strike_count`
- `pm10_0`
- `pm1_0`
- `pm2_5`

Doing this via a RegEx might not be the cleanest solution, but I feel like it beats hardcoding _every_ affected observation.