### PR TITLE
Fix page title in dwd.html.tmpl

### DIFF
--- a/skins/weewx-wdc/dwd.html.tmpl
+++ b/skins/weewx-wdc/dwd.html.tmpl
@@ -8,7 +8,7 @@
 <html lang="$lang">
   <head>
     #include "includes/html-head.inc"
-    <title>$station.location - $gettext("DWD")</title>
+    <title>$station.location - $gettext("Forecast")</title>
     <script
       type="module"
       src="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/version/v1.19.0/image-with-caption.min.js"


### PR DESCRIPTION
`$gettext("DWD")` shows the whole dwd text from the lang file.

```
    [[DWD]]
        "Current Weather Conditions" = "Aktuelle Wetterlage"
        "Today" = "Heute"
        "Tomorrow" = "Morgen"
```

but correct is maybe `"Forecast"`

`"Forecast" = "Wettervorhersage"`