### PR TITLE
Fix TypeError when windDir is None in wind-direction icon

### DIFF
--- a/skins/weewx-wdc/includes/icons/wind-direction.inc
+++ b/skins/weewx-wdc/includes/icons/wind-direction.inc
@@ -1,7 +1,7 @@
 #errorCatcher Echo
 #encoding UTF-8
 
-#set $style = "transform: rotate(" + str(int($windDir_deg.raw) + 90) + "deg)" if $windDir_deg else ""
+#set $style = "transform: rotate(" + str(int($windDir_deg.raw) + 90) + "deg)" if $windDir_deg.raw is not None else ""
 
 <svg
   data-name="Layer 1"


### PR DESCRIPTION
## Problem
Templates (day-archive, month, year overviews) crash with:

TypeError: int() argument must be a string, a bytes-like object
or a real number, not 'NoneType'

whenever an archive record has no windDir value (e.g. calm
conditions, or historical data predating a working wind sensor).
This affects any station with occasional missing wind data.

## Cause
`if $windDir_deg` checks truthiness of the ValueHelper wrapper
object, which is always truthy — even when `.raw` is None.

## Fix
Check `$windDir_deg.raw is not None` instead, which correctly
reflects whether an actual value is present.

## Testing
Verified against a MQTT-based weewx installation with several
years of historical data containing missing windDir values.
Before: month/year/day-archive pages failed to render for any
period containing a None windDir record.
After: pages render correctly, wind icon simply omits rotation
for records without a direction.